### PR TITLE
Pin Node 24 for Vercel builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "tailwindcss": "^3.3.0",
     "typescript": "^5"
   },
-  "packageManager": "pnpm@10.32.1"
+  "packageManager": "pnpm@10.32.1",
+  "engines": {
+    "node": "24.x"
+  }
 }


### PR DESCRIPTION
Vercel discontinued Node 18.x, which the project settings still pinned, failing production builds. engines.node overrides the dashboard setting and keeps the runtime version in version control.